### PR TITLE
fixed about us alignment

### DIFF
--- a/style.css
+++ b/style.css
@@ -12,7 +12,6 @@ body {
 }
 
 #textbox {
-    width: 60vw;
     text-align: center;
     margin: 20px auto;
     font-size: 1.2em;


### PR DESCRIPTION
Fixed about-us misalignment by removing width property in textbox {} in CSS.